### PR TITLE
Update package activation dance to fix specs

### DIFF
--- a/spec/markdown-folder-spec.coffee
+++ b/spec/markdown-folder-spec.coffee
@@ -6,15 +6,17 @@ MarkdownFolder = require '../lib/markdown-folder'
 # or `fdescribe`). Remove the `f` to unfocus the block.
 
 describe "MarkdownFolder", ->
-  [workspaceElement, activationPromise] = []
+  [workspaceElement] = []
 
   beforeEach ->
     workspaceElement = atom.views.getView(atom.workspace)
-    activationPromise = atom.packages.activatePackage('markdown-folder')
     waitsForPromise ->
-      activationPromise
+      atom.packages.activatePackage('language-gfm')
     waitsForPromise ->
-      atom.workspace.open('test.md')
+      Promise.all [
+        atom.packages.activatePackage('markdown-folder')
+        atom.workspace.open('test.md')
+      ]
 
   describe "when not folding anything", ->
     it "it should be 14 rows in both screen and buffer", ->


### PR DESCRIPTION
This is a delicate dance. We activate the language, then activate the package, but dont wait for it before opening the file. Opening the file will trigger package activation to finish, and let the specs run. 

Closes https://github.com/atom/atom/issues/8498
